### PR TITLE
Make changes to dockerfile to specify an output directory

### DIFF
--- a/example_report/Dockerfile
+++ b/example_report/Dockerfile
@@ -17,4 +17,5 @@ COPY test_format.Rmd /test-source/
 COPY targets.csv /test-source/
 COPY oneflorida.png /test-source/
 COPY *.Rmd /test-source/
-CMD ["R", "-e", "rmarkdown::render('/test-source/test_format.Rmd', output_file='/home/Downloads/example_report/test_format.pdf')"]
+RUN mkdir /home/output
+CMD ["R", "-e", "rmarkdown::render('/test-source/test_format.Rmd', output_file='test_format.pdf', output_dir = '/home/output')"]


### PR DESCRIPTION
This PR details how to make sure the created PDF appears on the host machine. I'm assuming you're new to docker so I've added some explanations.

You will want to build with:

```bash
docker build . -t emily_test_report
```

The `-t` flag is used to tag images, I find this much better than remembering the generated hash or nickname they're given.

Make sure to create a directory called `output` in the `example_report` directory (`mkdir output`). Then, run the container with the following command:

```bash
docker run -v $(pwd)/output:/home/output emily_test_report
```

In this command, we're using the `-v` flag to mount `output` as a [volume](https://docs.docker.com/storage/volumes/), which allows data to be shared between host and container. Docker gets angry about relative paths, so we have to use `$(pwd)`, which concatenates the output of `pwd` into the current command.

The generated PDF should appear in the output dir.